### PR TITLE
Allow multithreading

### DIFF
--- a/src/text.rs
+++ b/src/text.rs
@@ -6,7 +6,7 @@ use yrs::{
 use crate::transaction::Transaction;
 
 
-#[pyclass(unsendable)]
+#[pyclass]
 pub struct Text {
     text: TextRef,
 }
@@ -28,10 +28,10 @@ impl Text {
         Ok(len)
     }
 
-    fn push(&self, txn: &mut Transaction, chunk: &str)  -> PyResult<()> {
+    fn push(&self, py: Python<'_>, txn: &mut Transaction, chunk: &str)  -> PyResult<()> {
         let mut _t = txn.transaction();
         let mut t = _t.as_mut().unwrap();
-        self.text.push(&mut t, chunk);
+        py.allow_threads(|| self.text.push(&mut t, chunk));
         Ok(())
     }
 


### PR DESCRIPTION
Allowing [parallelism](https://pyo3.rs/v0.19.2/parallelism) in Rust-only code fails:
```
🍹 Building a mixed python/rust project
🔗 Found pyo3 bindings
🐍 Found CPython 3.11 at /home/david/github/davidbrochart/pycrdt/.pixi/env/bin/python
📡 Using build options features from pyproject.toml
Ignoring pytest: markers 'extra == "test"' don't match your environment
Ignoring y-py: markers 'extra == "test"' don't match your environment
Ignoring mypy: markers 'extra == "test"' don't match your environment
   Compiling pycrdt v0.1.0 (/home/david/github/davidbrochart/pycrdt)
error[E0277]: `NonNull<Branch>` cannot be sent between threads safely
   --> src/text.rs:9:1
    |
9   | #[pyclass]
    | ^^^^^^^^^^ `NonNull<Branch>` cannot be sent between threads safely
    |
    = help: within `text::Text`, the trait `Send` is not implemented for `NonNull<Branch>`
note: required because it appears within the type `BranchPtr`
   --> /home/david/.cargo/registry/src/index.crates.io-6f17d22bba15001f/yrs-0.16.10/src/types/mod.rs:172:12
    |
172 | pub struct BranchPtr(NonNull<Branch>);
    |            ^^^^^^^^^
note: required because it appears within the type `TextRef`
   --> /home/david/.cargo/registry/src/index.crates.io-6f17d22bba15001f/yrs-0.16.10/src/types/text.rs:94:12
    |
94  | pub struct TextRef(BranchPtr);
    |            ^^^^^^^
note: required because it appears within the type `Text`
   --> src/text.rs:10:12
    |
10  | pub struct Text {
    |            ^^^^
note: required by a bound in `ThreadCheckerStub`
   --> /home/david/.cargo/registry/src/index.crates.io-6f17d22bba15001f/pyo3-0.19.2/src/impl_/pyclass.rs:894:33
    |
894 | pub struct ThreadCheckerStub<T: Send>(PhantomData<T>);
    |                                 ^^^^ required by this bound in `ThreadCheckerStub`
    = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0277`.
error: could not compile `pycrdt` (lib) due to previous error
💥 maturin failed
  Caused by: Failed to build a native library through cargo
  Caused by: Cargo build finished with "exit status: 101": `PYO3_ENVIRONMENT_SIGNATURE="cpython-3.11-64bit" PYO3_PYTHON="/home/david/github/davidbrochart/pycrdt/.pixi/env/bin/python" PYTHON_SYS_EXECUTABLE="/home/david/github/davidbrochart/pycrdt/.pixi/env/bin/python" "cargo" "rustc" "--features" "pyo3/extension-module" "--message-format" "json-render-diagnostics" "--manifest-path" "/home/david/github/davidbrochart/pycrdt/Cargo.toml" "--lib"`
```
I suspect that this is because [Text.push](https://github.com/davidbrochart/pycrdt/blob/9e570924870a08bc64845f04178747bba7c164d9/src/text.rs#L31) is passed a reference to a [TransactionMut](https://github.com/davidbrochart/pycrdt/blob/9e570924870a08bc64845f04178747bba7c164d9/src/transaction.rs#L10), which cannot be sent between threads?
Any idea @Horusiath?