### PR TITLE
Set status of project to incubating

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 [![Build Status](https://github.com/jupyter-server/pycrdt/actions/workflows/test.yml/badge.svg?query=branch%3Amain++)](https://github.com/jupyter-server/pycrdt/actions/workflows/test.yml/badge.svg?query=branch%3Amain++)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
+:warning: This project is in still in an **incubating** phase (i.e. it's not ready for production yet) :warning:
+
 # pycrdt
 
 CRDTs based on [Yrs](https://github.com/y-crdt/y-crdt/tree/main/yrs).


### PR DESCRIPTION
Following up on this comment: https://github.com/jupyter-server/team-compass/issues/55#issuecomment-1852891044

We should set this project to _incubating_ status. We can re-evaluate this status in a few months, once this project has been used a bit longer.

cc @ellisonbg @ivanov 