### PR TITLE
Fix Python to JavaScript int conversion

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,4 +40,4 @@ jobs:
       run: mypy python
 
     - name: Run tests
-      run: pytest -v tests
+      run: pytest --color=yes -v tests

--- a/src/type_conversions.rs
+++ b/src/type_conversions.rs
@@ -208,8 +208,13 @@ pub fn py_to_any(value: &PyAny) -> Any {
         let v: bool = value.extract().unwrap();
         Any::Bool(v)
     } else if value.is_instance_of::<PyLong>() {
+        const MAX_JS_NUMBER: i64 = 2_i64.pow(53) - 1;
         let v: i64 = value.extract().unwrap();
-        Any::BigInt(v)
+        if v > MAX_JS_NUMBER {
+            Any::BigInt(v)
+        } else {
+            Any::Number(v as f64)
+        }
     } else if value.is_instance_of::<PyFloat>() {
         let v: f64 = value.extract().unwrap();
         Any::Number(v)

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -20,7 +20,7 @@ def test_str():
     map1 = Map({"foo": array1})
     array0 = Array([0, 1, None, map1])
     doc["array"] = array0
-    assert str(array0) == '[0,1,null,{"foo":[2,3,{"key":"val"}]}]'
+    assert str(array0) == '[0.0,1.0,null,{"foo":[2.0,3.0,{"key":"val"}]}]'
 
 
 def test_nested():
@@ -120,18 +120,18 @@ def test_api():
     assert v == 3
     v = array.pop(0)
     assert v == 1
-    assert str(array) == "[2]"
+    assert str(array) == "[2.0]"
 
     # insert
     doc = Doc()
     array = Array([1, 2, 3])
     doc["array"] = array
     array.insert(1, 4)
-    assert str(array) == "[1,4,2,3]"
+    assert str(array) == "[1.0,4.0,2.0,3.0]"
 
 
 def test_move():
     doc = Doc()
     doc["array"] = array = Array([1, 2, 3, 4])
     array.move(1, 3)
-    assert str(array) == "[1,3,2,4]"
+    assert str(array) == "[1.0,3.0,2.0,4.0]"

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -9,7 +9,7 @@ def test_str():
     array1 = Array([0, 1, map2])
     map0 = Map({"key1": array1})
     doc["map"] = map0
-    assert str(map0) == '{"key1":[0,1,{"key2":"val2"}]}'
+    assert str(map0) == '{"key1":[0.0,1.0,{"key2":"val2"}]}'
 
 
 def test_nested():
@@ -52,7 +52,7 @@ def test_api():
     doc["map0"] = map0
     v = map0.pop("foo")
     assert v == 1
-    assert str(map0) == '{"bar":2}'
+    assert str(map0) == '{"bar":2.0}'
     v = map0.pop("bar")
     assert v == 2
     assert str(map0) == "{}"

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -23,4 +23,4 @@ def test_callback_transaction():
     text += "hello"
     array.append(1)
     map_["foo"] = "bar"
-    assert events == ["hello", "[1]", '{"foo":"bar"}']
+    assert events == ["hello", "[1.0]", '{"foo":"bar"}']


### PR DESCRIPTION
Fixes https://github.com/jupyterlab/jupyter-collaboration/issues/225.

The solution comes from [y-py](https://github.com/y-crdt/ypy/pull/42).