### PR TITLE
Revert PR #58

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,22 +2,6 @@
 name = "pycrdt"
 version = "0.8.2"
 edition = "2021"
-license = "MIT"
-homepage = "https://github.com/jupyter-server/pycrdt"
-repository = "https://github.com/jupyter-server/pycrdt/pycrdt.git"
-readme = "README.md"
-include = [
-    "/pyproject.toml",
-    "/README.md",
-    "/LICENSE",
-    "/src",
-    "/python/pycrdt",
-    "/tests",
-    "!__pycache__",
-    "!tests/.mypy_cache",
-    "!tests/.pytest_cache",
-    "!*.so",
-]
 
 [lib]
 name = "pycrdt"


### PR DESCRIPTION
#58 was trying to fix https://github.com/conda-forge/pycrdt-feedstock/pull/16, but it was a conda-forge issue.