### PR TITLE
Resolve "Text data type does not delete as expected"

### DIFF
--- a/python/pycrdt/text.py
+++ b/python/pycrdt/text.py
@@ -95,7 +95,8 @@ class Text(BaseType):
         with self.doc.transaction() as txn:
             self._forbid_read_transaction(txn)
             if isinstance(key, int):
-                if len(value) != 1:
+                value_len = len(value)
+                if value_len != 1:
                     raise RuntimeError(
                         f"Single item assigned value must have a length of 1, not {value_len}"
                     )

--- a/python/pycrdt/text.py
+++ b/python/pycrdt/text.py
@@ -72,12 +72,12 @@ class Text(BaseType):
         else:
             start = key.start
         if key.stop is None:
-            length = len(self) - start
+            stop = len(self)
         elif key.stop < 0:
             raise RuntimeError("Negative stop not supported")
         else:
-            length = key.stop - start
-        return start, length
+            stop = key.stop
+        return start, stop
 
     def __delitem__(self, key: int | slice) -> None:
         with self.doc.transaction() as txn:
@@ -85,7 +85,8 @@ class Text(BaseType):
             if isinstance(key, int):
                 self.integrated.remove_range(txn._txn, key, 1)
             elif isinstance(key, slice):
-                start, length = self._check_slice(key)
+                start, stop = self._check_slice(key)
+                length = stop - start
                 if length > 0:
                     self.integrated.remove_range(txn._txn, start, length)
             else:
@@ -103,7 +104,8 @@ class Text(BaseType):
                 del self[key]
                 self.integrated.insert(txn._txn, key, value)
             elif isinstance(key, slice):
-                start, length = self._check_slice(key)
+                start, stop = self._check_slice(key)
+                length = stop - start
                 if length > 0:
                     self.integrated.remove_range(txn._txn, start, length)
                 self.integrated.insert(txn._txn, start, value)

--- a/python/pycrdt/text.py
+++ b/python/pycrdt/text.py
@@ -109,11 +109,22 @@ class Text(BaseType):
             else:
                 raise RuntimeError(f"Index not supported: {key}")
 
-    def clear(self) -> None:
-        del self[:]
+    def replace_range(self, value: str, start: int, stop: int) -> None:
+        """Replace the range of characters in the interval ['start', 'stop') with 'value'."""
+        del self[start:stop]
+        self[start:start] = value
 
-    def insert(self, index, text: str) -> None:
-        self[index:index] = text
+    def remove_range(self, start: int, stop:int ) -> None:
+        """Remove the range of characters in the interval ['start', 'stop')."""
+        del self[start:stop]
+
+    def insert(self, value: str, index: int) -> None:
+        """Insert 'value' at character position 'index'."""
+        self[index:index] = value
+
+    def clear(self) -> None:
+        """Remove the entire range of characters."""
+        del self[:]
 
     def observe(self, callback: Callable[[Any], None]) -> str:
         _callback = partial(observe_callback, callback, self.doc)

--- a/python/pycrdt/text.py
+++ b/python/pycrdt/text.py
@@ -114,7 +114,7 @@ class Text(BaseType):
         del self[start:stop]
         self[start:start] = value
 
-    def remove_range(self, start: int, stop:int ) -> None:
+    def remove_range(self, start: int, stop: int) -> None:
         """Remove the range of characters in the interval ['start', 'stop')."""
         del self[start:stop]
 

--- a/python/pycrdt/text.py
+++ b/python/pycrdt/text.py
@@ -112,8 +112,7 @@ class Text(BaseType):
 
     def replace_range(self, value: str, start: int, stop: int) -> None:
         """Replace the range of characters in the interval ['start', 'stop') with 'value'."""
-        del self[start:stop]
-        self[start:start] = value
+        self[start:stop] = value
 
     def remove_range(self, start: int, stop: int) -> None:
         """Remove the range of characters in the interval ['start', 'stop')."""

--- a/python/pycrdt/text.py
+++ b/python/pycrdt/text.py
@@ -72,12 +72,12 @@ class Text(BaseType):
         else:
             start = key.start
         if key.stop is None:
-            stop = len(self) - start
+            length = len(self) - start
         elif key.stop < 0:
             raise RuntimeError("Negative stop not supported")
         else:
-            stop = key.stop - start
-        return start, stop
+            length = key.stop - start
+        return start, length
 
     def __delitem__(self, key: int | slice) -> None:
         with self.doc.transaction() as txn:
@@ -85,9 +85,9 @@ class Text(BaseType):
             if isinstance(key, int):
                 self.integrated.remove_range(txn._txn, key, 1)
             elif isinstance(key, slice):
-                start, stop = self._check_slice(key)
-                if start != stop:
-                    self.integrated.remove_range(txn._txn, start, stop)
+                start, length = self._check_slice(key)
+                if length > 0:
+                    self.integrated.remove_range(txn._txn, start, length)
             else:
                 raise RuntimeError(f"Index not supported: {key}")
 
@@ -103,9 +103,9 @@ class Text(BaseType):
                 del self[key]
                 self.integrated.insert(txn._txn, key, value)
             elif isinstance(key, slice):
-                start, stop = self._check_slice(key)
-                if start != stop:
-                    self.integrated.remove_range(txn._txn, start, stop)
+                start, length = self._check_slice(key)
+                if length > 0:
+                    self.integrated.remove_range(txn._txn, start, length)
                 self.integrated.insert(txn._txn, start, value)
             else:
                 raise RuntimeError(f"Index not supported: {key}")

--- a/python/pycrdt/text.py
+++ b/python/pycrdt/text.py
@@ -112,21 +112,13 @@ class Text(BaseType):
             else:
                 raise RuntimeError(f"Index not supported: {key}")
 
-    def replace_range(self, value: str, start: int, stop: int) -> None:
-        """Replace the range of characters in the interval ['start', 'stop') with 'value'."""
-        self[start:stop] = value
-
-    def remove_range(self, start: int, stop: int) -> None:
-        """Remove the range of characters in the interval ['start', 'stop')."""
-        del self[start:stop]
-
-    def insert(self, value: str, index: int) -> None:
-        """Insert 'value' at character position 'index'."""
-        self[index:index] = value
-
     def clear(self) -> None:
         """Remove the entire range of characters."""
         del self[:]
+
+    def insert(self, index: int, value: str) -> None:
+        """Insert 'value' at character position 'index'."""
+        self[index:index] = value
 
     def observe(self, callback: Callable[[Any], None]) -> str:
         _callback = partial(observe_callback, callback, self.doc)

--- a/python/pycrdt/text.py
+++ b/python/pycrdt/text.py
@@ -95,8 +95,7 @@ class Text(BaseType):
         with self.doc.transaction() as txn:
             self._forbid_read_transaction(txn)
             if isinstance(key, int):
-                value_len = len(value)
-                if value_len != 1:
+                if len(value) != 1:
                     raise RuntimeError(
                         f"Single item assigned value must have a length of 1, not {value_len}"
                     )

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -32,7 +32,7 @@ def test_api():
     text = Text(hello + punct)
     doc["text"] = text
     assert str(text) == hello + punct
-    text.insert(world, len(hello))
+    text.insert(len(hello), world)
     assert str(text) == hello + world + punct
     text.clear()
     assert len(text) == 0

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -40,6 +40,9 @@ def test_api():
     assert str(text) == hello + world + punct
     text[len(hello) : len(hello) + len(world)] = sir
     assert str(text) == hello + sir + punct
+    # single character replacement
+    text[len(text) - 1] = "?"
+    assert str(text) == hello + sir + "?"
     # deletion with only an index
     del text[len(text) - 1]
     assert str(text) == hello + sir

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -51,8 +51,9 @@ def test_api():
     del text[len(hello) : 2 * len(hello)]
     assert str(text) == hello
     # deletion with a range of 0
-    del text[len(hello):len(hello)]
+    del text[len(hello) : len(hello)]
     assert str(text) == hello
+
 
 def test_to_py():
     doc = Doc()

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -2,6 +2,7 @@ from pycrdt import Array, Doc, Map, Text
 
 hello = "Hello"
 world = ", World"
+sir = " Sir"
 punct = "!"
 
 
@@ -31,15 +32,27 @@ def test_api():
     text = Text(hello + punct)
     doc["text"] = text
     assert str(text) == hello + punct
-    text.insert(len(hello), world)
+    text.insert(world, len(hello))
     assert str(text) == hello + world + punct
     text.clear()
     assert len(text) == 0
     text[:] = hello + world + punct
     assert str(text) == hello + world + punct
-    text[len(hello) : len(hello) + len(world)] = " Sir"
-    assert str(text) == hello + " Sir" + punct
-
+    text[len(hello) : len(hello) + len(world)] = sir
+    assert str(text) == hello + sir + punct
+    # deletion with only an index
+    del text[len(text) - 1]
+    assert str(text) == hello + sir
+    # deletion of an arbitrary range
+    del text[len(hello) : len(hello) + len(sir)]
+    assert str(text) == hello
+    # deletion with start index == range length
+    text += str(text)
+    del text[len(hello) : 2 * len(hello)]
+    assert str(text) == hello
+    # deletion with a range of 0
+    del text[len(hello):len(hello)]
+    assert str(text) == hello
 
 def test_to_py():
     doc = Doc()


### PR DESCRIPTION
Essentially, I adjust the conditions for range lengths such that they align with the signature of the `remove_range` method of `TextRef` in Yrs.

Additionally, I review convenience methods for text manipulation `replace_range`, `remove_range`, `insert`, and `clear`, inspired by the [blog post of Darren Burns](https://textual.textualize.io/blog/2023/09/18/things-i-learned-while-building-textuals-textarea/#edits-are-replacements)