### PR TITLE
Improve Doc.get return value type

### DIFF
--- a/python/pycrdt/_doc.py
+++ b/python/pycrdt/_doc.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
-from typing import Callable, TypeVar, Type, cast
+from typing import Callable, Type, TypeVar, cast
 
 from ._base import BaseDoc, BaseType, base_types
 from ._pycrdt import Doc as _Doc
 from ._pycrdt import SubdocsEvent, TransactionEvent
 from ._pycrdt import Transaction as _Transaction
 from ._transaction import ReadTransaction, Transaction
-
 
 T_BaseType = TypeVar("T_BaseType", bound=BaseType)
 

--- a/python/pycrdt/_doc.py
+++ b/python/pycrdt/_doc.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
-from typing import Callable, Type, cast
+from typing import Callable, TypeVar, Type, cast
 
 from ._base import BaseDoc, BaseType, base_types
 from ._pycrdt import Doc as _Doc
 from ._pycrdt import SubdocsEvent, TransactionEvent
 from ._pycrdt import Transaction as _Transaction
 from ._transaction import ReadTransaction, Transaction
+
+
+T_BaseType = TypeVar("T_BaseType", bound=BaseType)
 
 
 class Doc(BaseDoc):
@@ -73,7 +76,7 @@ class Doc(BaseDoc):
     def __iter__(self):
         return iter(self.keys())
 
-    def get(self, key: str, *, type: Type[BaseType]) -> BaseType:
+    def get(self, key: str, *, type: Type[T_BaseType]) -> T_BaseType:
         value = type()
         self[key] = value
         return value


### PR DESCRIPTION
With this change, `mypy` knows the return type of `Doc.get("foo", type=MyType)` is `MyType`, while it was previously `BaseType`. The type passed to `type` must still be a `BaseType`.
This can be seen by running `mypy test.py`:
```py
# test.py
from pycrdt import Doc, Text

doc = Doc()
text = doc.get("text", type=Text)
print(reveal_type(text))
# note: Revealed type is "pycrdt._text.Text"
doc.get("foo", type=int)
# error: Value of type variable "T_BaseType" of "get" of "Doc" cannot be "int"  [type-var]
```