### PR TITLE
Shared Types Popped from Shared Map are Empty

### DIFF
--- a/python/pycrdt/_map.py
+++ b/python/pycrdt/_map.py
@@ -108,6 +108,8 @@ class Map(BaseType):
                     raise KeyError
                 return default_value[0]
             res = self[key]
+            if isinstance(res, BaseType):
+                res = type(res)(res.to_py())
             del self[key]
             return res
 

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -93,6 +93,13 @@ def test_api():
     assert str(map0) == "{}"
 
     # pop nested
+    nested_doc = Doc()
+    nested_doc["text"] = Text("text in subdoc")
+    map0.update({"baz": nested_doc})
+    v = map0.pop("baz")
+    assert str(v["text"]) == 'text in subdoc'
+    assert str(map0) == '{}'
+
     nested_text = Text("abc")
     map0.update({"baz": nested_text})
     v = map0.pop("baz")
@@ -116,8 +123,6 @@ def test_api():
     new_doc["v"] = v
     assert str(v) == '{"x":"y"}'
     assert str(map0) == '{}'
-
-
 
 
 def test_to_py():

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -92,6 +92,33 @@ def test_api():
     assert v == 2
     assert str(map0) == "{}"
 
+    # pop nested
+    nested_text = Text("abc")
+    map0.update({"baz": nested_text})
+    v = map0.pop("baz")
+    new_doc = Doc()
+    new_doc["v"] = v
+    assert str(v) == 'abc'
+    assert str(map0) == '{}'
+
+    nested_array = Array([1, 2, 3])
+    map0.update({"baz": nested_array})
+    v = map0.pop("baz")
+    new_doc = Doc()
+    new_doc["v"] = v
+    assert str(v) == '[1.0,2.0,3.0]'
+    assert str(map0) == '{}'
+
+    nested_map = Map({"x": "y"})
+    map0.update({"baz": nested_map})
+    v = map0.pop("baz")
+    new_doc = Doc()
+    new_doc["v"] = v
+    assert str(v) == '{"x":"y"}'
+    assert str(map0) == '{}'
+
+
+
 
 def test_to_py():
     doc = Doc()


### PR DESCRIPTION
Hi :wave:

I experienced that, when having a shared datatype nested into a shared map, and popping that nested item, the returned item is of the same shared datatype, but empty:

```python
from pycrdt import Doc, Map

ydoc = Doc()
ymap = ydoc["map"] = Map()
print(ymap)
# {}

inner_map = Map({"bar": "baz"})
ymap.update({"foo": inner_map})
print(ymap)
# {"foo":{"bar":"baz"}}

x = ymap.pop("foo")
print(ymap)
# {}
print(x)
# {} <-- expected {"bar":"baz"}
```

This is also the same for Shared Arrays and Shared Text, but not for Subdocs.

After some hours, I found the deletion to happen here
https://github.com/jupyter-server/pycrdt/blob/15a47b0628d02a58893d594f31674895429cdda0/python/pycrdt/_map.py#L110-L111

where `res` is the popped shared type and populated (as expected), but empty after calling `del self[key]`.
According to the Yrs docs, [this is expected behavior for Shared Maps](https://docs.rs/yrs/latest/yrs/types/map/trait.Map.html#method.remove):
> fn remove([...])
> [...]
> Removing nested shared types
>
> In case when a nested shared type (eg. [MapRef](https://docs.rs/yrs/latest/yrs/types/map/struct.MapRef.html), [ArrayRef](https://docs.rs/yrs/latest/yrs/types/array/struct.ArrayRef.html), [TextRef](https://docs.rs/yrs/latest/yrs/types/text/struct.TextRef.html)) is being removed, all of its contents will also be deleted recursively. A returned value will contain a reference to a current removed shared type (which will be empty due to all of its elements being deleted), not the content prior the removal.

So, we need to copy the content to another object before perfoming the removal with `del self[key]`.

I quickly added tests as well as a check if `res` is an instance of `BaseType`, relying on the method `to_py` to be defined, but maybe a more sophisticated fix with `__copy__` and `__deepcopy__` implemented might be better?