### PR TITLE
Bump upper limit of trio

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
 test = [
     "pytest >=7.4.2,<8",
     "anyio",
-    "trio >=0.25.1,<0.26",
+    "trio >=0.25.1,<0.27",
     "pydantic >=2.5.2,<3",
     "mypy",
     "coverage[toml] >=7",


### PR DESCRIPTION
Trio 0.26 came out in July and nothing in the changes seems to affect pycrdt: https://github.com/python-trio/trio/releases