### PR TITLE
Don't publish wheels for Windows on Python 3.13

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,9 +43,9 @@ jobs:
       matrix:
         platform:
           - target: x64
-            interpreter: 3.8 3.9 3.10 3.11 3.12 3.13
+            interpreter: 3.8 3.9 3.10 3.11 3.12
           - target: x86
-            interpreter: 3.8 3.9 3.10 3.11 3.12 3.13
+            interpreter: 3.8 3.9 3.10 3.11 3.12
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
See https://github.com/PyO3/maturin-action/issues/292.