### PR TITLE
Add support for adding XmlFragments to arrays and maps

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -2,13 +2,7 @@ use pyo3::prelude::*;
 use pyo3::exceptions::{PyValueError, PyTypeError};
 use pyo3::types::{PyList, PyString};
 use yrs::{
-    Any,
-    ArrayRef,
-    Array as _Array,
-    Doc as _Doc,
-    DeepObservable,
-    Observable,
-    TransactionMut,
+    Any, Array as _Array, ArrayRef, DeepObservable, Doc as _Doc, Observable, TransactionMut, XmlFragmentPrelim
 };
 use yrs::types::ToJson;
 use yrs::types::text::TextPrelim;
@@ -20,6 +14,7 @@ use crate::type_conversions::{events_into_py, py_to_any, ToPython};
 use crate::text::Text;
 use crate::map::Map;
 use crate::doc::Doc;
+use crate::xml::XmlFragment;
 
 
 #[pyclass]
@@ -77,6 +72,22 @@ impl Array {
         let integrated = self.array.insert(&mut t, index, MapPrelim::default());
         let shared = Map::from(integrated);
         Python::with_gil(|py| { Ok(shared.into_py(py)) })
+    }
+
+    fn insert_xmlfragment_prelim(&self, txn: &mut Transaction, index: u32) -> PyResult<PyObject> {
+        let mut _t = txn.transaction();
+        let mut t = _t.as_mut().unwrap().as_mut();
+        let integrated = self.array.insert(&mut t, index, XmlFragmentPrelim::default());
+        let shared = XmlFragment::from(integrated);
+        Python::with_gil(|py| { Ok(shared.into_py(py)) })
+    }
+
+    fn insert_xmlelement_prelim(&self, _txn: &mut Transaction, _index: u32) -> PyResult<PyObject> {
+        Err(PyTypeError::new_err("Cannot insert an XmlElement into an array - insert it into an XmlFragment and insert that into the array"))
+    }
+
+    fn insert_xmltext_prelim(&self, _txn: &mut Transaction, _index: u32) -> PyResult<PyObject> {
+        Err(PyTypeError::new_err("Cannot insert an XmlText into an array - insert it into an XmlFragment and insert that into the array"))
     }
 
     fn insert_doc(&self, txn: &mut Transaction, index: u32, doc: &Bound<'_, PyAny>) -> PyResult<()> {

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -1,5 +1,5 @@
 import pytest
-from pycrdt import Doc, XmlElement, XmlFragment, XmlText
+from pycrdt import Doc, XmlElement, XmlFragment, XmlText, Map, Array
 
 
 def test_plain_text():
@@ -275,3 +275,35 @@ def test_observe():
     assert str(events[0][0].target) == "H<bold>el</bold>lo world!"
     assert events[0][0].delta[0] == {"retain": 1}
     assert events[0][0].delta[1] == {"retain": 2, "attributes": {"bold": True}}
+
+def test_xml_in_array():
+    doc = Doc()
+    array = doc.get("testmap", type=Array)
+    frag = XmlFragment()
+    array.append(frag)
+    frag.children.append("Test XML!")
+
+    assert len(array) == 1
+    assert str(array[0]) == "Test XML!"
+
+    with pytest.raises(TypeError):
+        array.append(XmlText())
+    with pytest.raises(TypeError):
+        array.append(XmlElement("a"))
+    assert len(array) == 1
+
+def test_xml_in_map():
+    doc = Doc()
+    map = doc.get("testmap", type=Map)
+    frag = map["testxml"] = XmlFragment()
+    frag.children.append("Test XML!")
+
+    assert len(map) == 1
+    assert "testxml" in map
+    assert str(map["testxml"]) == "Test XML!"
+
+    with pytest.raises(TypeError):
+        map["testtext"] = XmlText()
+    with pytest.raises(TypeError):
+        map["testel"] = XmlElement("a")
+    assert len(map) == 1

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -1,5 +1,5 @@
 import pytest
-from pycrdt import Doc, XmlElement, XmlFragment, XmlText, Map, Array
+from pycrdt import Array, Doc, Map, XmlElement, XmlFragment, XmlText
 
 
 def test_plain_text():
@@ -276,6 +276,7 @@ def test_observe():
     assert events[0][0].delta[0] == {"retain": 1}
     assert events[0][0].delta[1] == {"retain": 2, "attributes": {"bold": True}}
 
+
 def test_xml_in_array():
     doc = Doc()
     array = doc.get("testmap", type=Array)
@@ -291,6 +292,7 @@ def test_xml_in_array():
     with pytest.raises(TypeError):
         array.append(XmlElement("a"))
     assert len(array) == 1
+
 
 def test_xml_in_map():
     doc = Doc()


### PR DESCRIPTION
I overlooked support for this in my initial XML support branch because I was not sure if YJS supported XML fragments nested in either of those types, but it works, so I've added support.