### PR TITLE
Add a function to check if an awareness message is a disconnection

### DIFF
--- a/python/pycrdt/__init__.py
+++ b/python/pycrdt/__init__.py
@@ -2,6 +2,7 @@ from ._array import Array as Array
 from ._array import ArrayEvent as ArrayEvent
 from ._array import TypedArray as TypedArray
 from ._awareness import Awareness as Awareness
+from ._awareness import is_disconnection_message as is_disconnection_message
 from ._doc import Doc as Doc
 from ._doc import TypedDoc as TypedDoc
 from ._map import Map as Map

--- a/python/pycrdt/_awareness.py
+++ b/python/pycrdt/_awareness.py
@@ -10,7 +10,7 @@ from anyio import TASK_STATUS_IGNORED, create_task_group, sleep
 from anyio.abc import TaskGroup, TaskStatus
 
 from ._doc import Doc
-from ._sync import Decoder, Encoder
+from ._sync import Decoder, Encoder, read_message
 
 
 class Awareness:
@@ -278,3 +278,21 @@ class Awareness:
             id: The subscription ID to unregister.
         """
         del self._subscriptions[id]
+
+
+"""
+Check if the message is null, which means that it is a disconnection message
+from the client.
+"""
+def is_disconnection_message(message: bytes) -> bool:
+    decoder = Decoder(read_message(message))
+    length = decoder.read_var_uint()
+    # A disconnection message should be a single message
+    if length == 1:
+        # Remove client_id and clock information from message (not used)
+        for _ in range(2):
+            decoder.read_var_uint()
+        state = decoder.read_var_string()
+        if state == "null":
+            return True
+    return False

--- a/python/pycrdt/_awareness.py
+++ b/python/pycrdt/_awareness.py
@@ -284,6 +284,8 @@ class Awareness:
 Check if the message is null, which means that it is a disconnection message
 from the client.
 """
+
+
 def is_disconnection_message(message: bytes) -> bool:
     decoder = Decoder(read_message(message))
     length = decoder.read_var_uint()


### PR DESCRIPTION
This PR adds a function receiving a byte message and return a boolean whether the message is a disconnection message or not (state = `null`).

Related to https://github.com/jupyter-server/pycrdt-websocket/pull/118, see discussion for context.