### PR TITLE
Add transaction to slots

### DIFF
--- a/python/pycrdt/_array.py
+++ b/python/pycrdt/_array.py
@@ -387,9 +387,10 @@ class ArrayEvent(BaseEvent):
         target (Array): The changed array.
         delta (list[dict[str, Any]]): A list of items describing the changes.
         path (list[int | str]): A list with the indices pointing to the array that was changed.
+        transaction (Transaction): The transaction related to the change.
     """
 
-    __slots__ = "target", "delta", "path"
+    __slots__ = "target", "delta", "path", "transaction"
 
 
 class ArrayIterator:

--- a/python/pycrdt/_map.py
+++ b/python/pycrdt/_map.py
@@ -363,9 +363,10 @@ class MapEvent(BaseEvent):
         target (Map): The changed map.
         delta (list[dict[str, Any]]): A list of items describing the changes.
         path (list[int | str]): A list with the indices pointing to the map that was changed.
+        transaction (Transaction): The transaction related to the change.
     """
 
-    __slots__ = "target", "keys", "path"
+    __slots__ = "target", "keys", "path", "transaction"
 
 
 base_types[_Map] = Map

--- a/python/pycrdt/_text.py
+++ b/python/pycrdt/_text.py
@@ -315,9 +315,10 @@ class TextEvent(BaseEvent):
         target (Text): The changed text.
         delta (list[dict[str, Any]]): A list of items describing the changes.
         path (list[int | str]): A list with the indices pointing to the text that was changed.
+        transaction (Transaction): The transaction related to the change.
     """
 
-    __slots__ = "target", "delta", "path"
+    __slots__ = "target", "delta", "path", "transaction"
 
 
 base_types[_Text] = Text

--- a/python/pycrdt/_xml.py
+++ b/python/pycrdt/_xml.py
@@ -312,7 +312,7 @@ class XmlText(_XmlTraitMixin):
 
 
 class XmlEvent(BaseEvent):
-    __slots__ = ["children_changed", "target", "path", "delta", "keys"]
+    __slots__ = ["children_changed", "target", "path", "delta", "keys", "transaction"]
 
 
 class XmlAttributesView:


### PR DESCRIPTION
This PR add the transaction to the slots so consumer of the pycrdt have access to the transaction object if useful.

cc/ @davidbrochart 