### PR TITLE
fix: xml attributes can be any type

### DIFF
--- a/src/xml.rs
+++ b/src/xml.rs
@@ -79,24 +79,27 @@ macro_rules! impl_xml_methods {
             )?
 
             $(
-                fn attributes(&self, txn: &mut Transaction) -> Vec<(String, String)> {
+                fn attributes<'py>(&self, py: Python<'py>, txn: &mut Transaction) -> Vec<(String, Bound<'py, PyAny>)> {
                     let mut t0 = txn.transaction();
                     let t1 = t0.as_mut().unwrap();
                     let t = t1.as_ref();
-                    self.$xinner.attributes(t).map(|(k,v)| (String::from(k), v.to_string(t))).collect()
+                    self.$xinner
+                        .attributes(t)
+                        .map(|(k, v)| (String::from(k), v.into_py(py)))
+                        .collect()
                 }
 
-                fn attribute(&self, txn: &mut Transaction, name: &str) -> Option<String> {
+                fn attribute<'py>(&self, py: Python<'py>, txn: &mut Transaction, name: &str) -> Option<Bound<'py, PyAny>> {
                     let mut t0 = txn.transaction();
                     let t1 = t0.as_mut().unwrap();
                     let t = t1.as_ref();
-                    Some(self.$xinner.get_attribute(t, name)?.to_string(t))
+                    Some(self.$xinner.get_attribute(t, name)?.into_py(py))
                 }
 
-                fn insert_attribute(&self, txn: &mut Transaction, name: &str, value: &str) {
+                fn insert_attribute(&self, txn: &mut Transaction, name: &str, value: Bound<'_, PyAny>) {
                     let mut _t = txn.transaction();
                     let mut t = _t.as_mut().unwrap().as_mut();
-                    self.$xinner.insert_attribute(&mut t, name, value);
+                    self.$xinner.insert_attribute(&mut t, name, py_to_any(&value));
                 }
 
                 fn remove_attribute(&self, txn: &mut Transaction, name: &str) {

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -151,6 +151,18 @@ def test_text():
     doc["test2"] = XmlFragment([XmlText()])
 
 
+def test_element_with_any_attribute():
+    doc = Doc()
+
+    doc["test"] = frag = XmlFragment()
+    el = XmlElement("div")
+    frag.children.append(el)
+    el.attributes["class"] = {"a": True}
+    assert el.attributes["class"] == {"a": True}
+    assert list(el.attributes) == [("class", {"a": True})]
+    assert len(el.attributes) == 1
+
+
 def test_element():
     doc = Doc()
 


### PR DESCRIPTION
This is an attempt at fixing #189

In Yjs and Yrs, XML attributes can be of `Any` type, not only string. This PR makes sure this is also the case when using the Python bindings.