### PR TITLE
Support subinterpreters

### DIFF
--- a/python/pycrdt/__init__.py
+++ b/python/pycrdt/__init__.py
@@ -41,3 +41,7 @@ from ._xml import XmlElement as XmlElement
 from ._xml import XmlEvent as XmlEvent
 from ._xml import XmlFragment as XmlFragment
 from ._xml import XmlText as XmlText
+
+
+def import_pycrdt():
+    import pycrdt

--- a/tests/test_subinterpreters.py
+++ b/tests/test_subinterpreters.py
@@ -1,0 +1,11 @@
+import pytest
+
+from anyio import to_interpreter
+
+from pycrdt import import_pycrdt
+
+pytestmark = pytest.mark.anyio
+
+
+async def test_subinterpreter():
+    await to_interpreter.run_sync(import_pycrdt)


### PR DESCRIPTION
Currently pycrdt cannot be used in subinterpreters:
```
ImportError: module pycrdt._pycrdt does not support loading in subinterpreters
```