### PR TITLE
fixed getattr default on Typed classes

### DIFF
--- a/python/pycrdt/_base.py
+++ b/python/pycrdt/_base.py
@@ -380,7 +380,10 @@ class Typed:
                 raise AttributeError(f'"{type(self).mro()[0]}" has no attribute "{key}"')
             expected_type = annotations[key]
             if hasattr(expected_type, "mro") and Typed in expected_type.mro():
-                return expected_type(self._[key])
+                try:
+                    return expected_type(self._[key])
+                except KeyError:
+                    raise AttributeError(f'"{type(self).mro()[0]}" has no attribute "{key}"')
             return self._[key]
 
         def __setattr__(self, key: str, value: Any) -> None:


### PR DESCRIPTION
See issue https://github.com/y-crdt/pycrdt/issues/314

reraise KeyError as an AttributeError when using getattr on Typed classes so that the function can recognize when to use the given default value.