### PR TITLE
Build wheel for arm64 architecture

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: [x86_64, i686]
+        target: [x86_64, i686, aarch64]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6


### PR DESCRIPTION
Using this dependency in a project targeting an arm64 architecture take a very long time to build the wheel.

Doing this in this CI in the publish job will save kittens and lot of time in some other CI.