### PR TITLE
Buid wheel for musllinux platform

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: "3.11"
           architecture: x64
       - uses: dtolnay/rust-toolchain@stable
       - name: Build wheels - universal2
@@ -84,7 +84,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: "3.11"
           architecture: x64
       - name: Build sdist
         if: ${{ matrix.target == 'x86_64' }}
@@ -120,7 +120,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: "3.11"
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -149,6 +149,82 @@ jobs:
           name: wheels-linux-cross-${{ matrix.target }}
           path: dist
 
+  musllinux:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - x86_64-unknown-linux-musl
+          - i686-unknown-linux-musl
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          architecture: x64
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          rust-toolchain: stable
+          target: ${{ matrix.target }}
+          manylinux: musllinux_1_2
+          args: --release --out dist -i 3.10 3.11 3.12 3.13 3.14
+      - name: Test built wheel
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        run: |
+          docker run --rm -v "$(pwd):/workspace" -w /workspace alpine:latest sh -c "
+            apk add --no-cache python3 py3-pip &&
+            pip3 install --break-system-packages -U pip pytest 'pydantic>=2.5.2,<3' 'anyio>=4.4.0,<5' 'trio>=0.25.1,<0.32' &&
+            pip3 install --break-system-packages pycrdt --no-deps --no-index --find-links dist/ --force-reinstall &&
+            pytest --ignore tests/test_types.py
+          "
+      - name: Upload wheels
+        uses: actions/upload-artifact@v7
+        with:
+          name: wheels-musllinux-${{ matrix.target }}
+          path: dist
+
+  musllinux-cross:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform:
+          - target: aarch64-unknown-linux-musl
+            arch: aarch64
+          - target: armv7-unknown-linux-musleabihf
+            arch: armv7
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          rust-toolchain: stable
+          target: ${{ matrix.platform.target }}
+          manylinux: musllinux_1_2
+          args: --release --out dist -i 3.10 3.11 3.12 3.13 3.14
+
+      - uses: uraimo/run-on-arch-action@v3.0.1
+        name: Test built wheel
+        with:
+          arch: ${{ matrix.platform.arch }}
+          distro: alpine_latest
+          githubToken: ${{ github.token }}
+          install: |
+            apk add --no-cache python3 py3-pip
+            pip3 install --break-system-packages -U pip pytest "pydantic>=2.5.2,<3" "anyio>=4.4.0,<5" "trio>=0.25.1,<0.32"
+          run: |
+            pip3 install --break-system-packages pycrdt --no-deps --no-index --find-links dist/ --force-reinstall
+            pytest --ignore tests/test_types.py
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v7
+        with:
+          name: wheels-musllinux-cross-${{ matrix.platform.target }}
+          path: dist
+
   pypi-release:
     name: Publish to PyPI
     runs-on: ubuntu-latest
@@ -157,6 +233,8 @@ jobs:
       - windows
       - linux
       - linux-cross
+      - musllinux
+      - musllinux-cross
     environment: release
     permissions:
       id-token: write
@@ -174,12 +252,12 @@ jobs:
     permissions:
       contents: write
     steps:
-    - uses: actions/checkout@v6
-    - id: changelog
-      uses: agronholm/release-notes@v1
-      with:
-        path: CHANGELOG.md
-        version_pattern: ^\#\# ([0-9][^*]*)\n
-    - uses: ncipollo/release-action@v1
-      with:
-        body: ${{ steps.changelog.outputs.changelog }}
+      - uses: actions/checkout@v6
+      - id: changelog
+        uses: agronholm/release-notes@v1
+        with:
+          path: CHANGELOG.md
+          version_pattern: ^\#\# ([0-9][^*]*)\n
+      - uses: ncipollo/release-action@v1
+        with:
+          body: ${{ steps.changelog.outputs.changelog }}


### PR DESCRIPTION
On a project where pycrdt is required but using a musl linux architecture (like alpine), the wheel is build during a pip install and it takes a very long time to build, especially on the arm64 platform.

I have no experience on building wheels at all, so I don't know if what I made is good or not.
To do this commit I did several research and used these resources:

- https://github.com/PyO3/maturin-action
- https://github.com/astral-sh/ruff/blob/34cee06dfa6c558c4ab1460200033ea44b368ae4/.github/workflows/build-binaries.yml#L365-L492

And also with claude code.

Thanks for your help. If you think that this PR is not good enough, tell me what I should improve.
