### PR TITLE
feat: add insert_xmltext_prelim and insert_xmlelement_prelim to XmlText

### DIFF
--- a/python/pycrdt/_xml.py
+++ b/python/pycrdt/_xml.py
@@ -263,7 +263,14 @@ class XmlText(_XmlTraitMixin):
         with self.doc.transaction() as txn:
             self._forbid_read_transaction(txn)
             _attrs = iter(attrs.items()) if attrs is not None else None
-            if isinstance(value, BaseType):
+            if isinstance(value, XmlElement) and value._prelim is not None:
+                assert txn._txn is not None
+                tag = value._prelim[0]
+                integrated = self.integrated.insert_xmlelement_prelim(txn._txn, index, tag, _attrs)
+                assert self._doc is not None
+                prelim = value._integrate(self._doc, integrated)
+                value._init(prelim)
+            elif isinstance(value, BaseType):
                 # shared type
                 assert txn._txn is not None
                 self._do_and_integrate("insert", value, txn._txn, index, _attrs)

--- a/src/xml.rs
+++ b/src/xml.rs
@@ -307,6 +307,21 @@ impl_xml_methods!(XmlText[text, xml: text] {
         Ok(shared)
     }
 
+    #[pyo3(signature = (txn, index, attrs=None))]
+    fn insert_xmltext_prelim<'py>(&self, txn: &mut Transaction, index: u32, attrs: Option<Bound<'_, PyIterator>>) -> PyResult<XmlText> {
+        let mut _t = txn.transaction();
+        let mut t = _t.as_mut().unwrap().as_mut();
+        let integrated;
+        if let Some(attrs) = attrs {
+            let attrs = py_to_attrs(attrs)?;
+            integrated = self.text.insert_embed_with_attributes(&mut t, index, XmlTextPrelim::default(), attrs);
+        } else {
+            integrated = self.text.insert_embed(&mut t, index, XmlTextPrelim::default());
+        }
+        let shared = XmlText::from(integrated);
+        Ok(shared)
+    }
+
     fn remove_range(&self, txn: &mut Transaction, index: u32, len: u32) {
         let mut _t = txn.transaction();
         let mut t = _t.as_mut().unwrap().as_mut();

--- a/src/xml.rs
+++ b/src/xml.rs
@@ -322,6 +322,21 @@ impl_xml_methods!(XmlText[text, xml: text] {
         Ok(shared)
     }
 
+    #[pyo3(signature = (txn, index, tag, attrs=None))]
+    fn insert_xmlelement_prelim<'py>(&self, txn: &mut Transaction, index: u32, tag: &str, attrs: Option<Bound<'_, PyIterator>>) -> PyResult<XmlElement> {
+        let mut _t = txn.transaction();
+        let mut t = _t.as_mut().unwrap().as_mut();
+        let integrated;
+        if let Some(attrs) = attrs {
+            let attrs = py_to_attrs(attrs)?;
+            integrated = self.text.insert_embed_with_attributes(&mut t, index, XmlElementPrelim::empty(tag), attrs);
+        } else {
+            integrated = self.text.insert_embed(&mut t, index, XmlElementPrelim::empty(tag));
+        }
+        let shared = XmlElement::from(integrated);
+        Ok(shared)
+    }
+
     fn remove_range(&self, txn: &mut Transaction, index: u32, len: u32) {
         let mut _t = txn.transaction();
         let mut t = _t.as_mut().unwrap().as_mut();

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -190,6 +190,26 @@ def test_xmltext_embed_in_xmltext():
     assert grandchild.to_py() == "cell content"
 
 
+def test_xmlelement_embed_in_xmltext():
+    doc = Doc()
+    doc["root"] = XmlFragment()
+    root = doc["root"]
+
+    para = XmlText()
+    root.children.insert(0, para)
+    para.attributes["__type"] = "paragraph"
+
+    mention = XmlElement("mention-tag")
+    para.insert_embed(0, mention)
+    mention.attributes["__type"] = "resource-mention"
+    mention.attributes["__resource"] = {"resource_id": "abc", "resource_type": "entity"}
+
+    assert para.attributes["__type"] == "paragraph"
+    assert mention.attributes["__type"] == "resource-mention"
+    assert mention.attributes["__resource"] == {"resource_id": "abc", "resource_type": "entity"}
+    assert mention.tag == "mention-tag"
+
+
 def test_element_with_any_attribute():
     doc = Doc()
 

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -166,6 +166,30 @@ def test_text():
     doc["test2"] = XmlFragment([XmlText()])
 
 
+def test_xmltext_embed_in_xmltext():
+    doc = Doc()
+    doc["root"] = XmlFragment()
+    root = doc["root"]
+
+    parent = XmlText()
+    root.children.insert(0, parent)
+    parent.attributes["__type"] = "table"
+
+    child = XmlText()
+    parent.insert_embed(0, child)
+    child.attributes["__type"] = "tablerow"
+
+    grandchild = XmlText()
+    child.insert_embed(0, grandchild)
+    grandchild.attributes["__type"] = "tablecell"
+    grandchild.insert(0, "cell content")
+
+    assert parent.attributes["__type"] == "table"
+    assert child.attributes["__type"] == "tablerow"
+    assert grandchild.attributes["__type"] == "tablecell"
+    assert grandchild.to_py() == "cell content"
+
+
 def test_element_with_any_attribute():
     doc = Doc()
 


### PR DESCRIPTION
## Summary

Allow embedding an `XmlText` inside another `XmlText` via `insert_embed()`. Should close https://github.com/y-crdt/y-crdt/issues/439

This was the only shared type missing from `XmlText`'s prelim methods — `Array`, `Map`, and `Text` were already supported. The new method follows the exact same pattern as the existing `insert_text_prelim`.

The underlying `yrs` library already implements `Prelim` and `Into<EmbedPrelim>` for `XmlTextPrelim`, so this simply exposes the existing capability through the pyo3 bindings.

## Motivation

Lexical's `@lexical/yjs` collaboration binding represents all `ElementNode`s as `YXmlText`. Nested structures like tables (table → row → cell → paragraph) require embedding `XmlText` inside `XmlText`, which was previously impossible from Python. This also relates to [y-crdt/y-crdt#439](https://github.com/y-crdt/y-crdt/issues/439).

## Changes

- **`src/xml.rs`**: Add `insert_xmltext_prelim` method to `XmlText` (15 lines, mirrors `insert_text_prelim`)
- **`tests/test_xml.py`**: Add test for 3-level `XmlText` nesting (table → row → cell pattern)

## Tests
I don't see CI tests running on github so here's the output I got by running this locally:

```
> python -m pytest tests/test_xml.py -v
OpenTelemetry configuration OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE is not supported by Datadog.
     ============================= test session starts ==============================
     platform darwin -- Python 3.11.7, pytest-8.0.2, pluggy-1.3.0 -- /Users/MatthiasReichenbach/.pyenv/versions/peregrine/bin/python
     cachedir: .pytest_cache
     benchmark: 5.0.1 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False
     warmup_iterations=100000)
     rootdir: /Users/MatthiasReichenbach/Development/pycrdt
     configfile: pyproject.toml
     plugins: asyncio-0.23.8, snapshot-0.9.0, respx-0.22.0, cov-6.0.0, Faker-36.2.3, benchmark-5.0.1, django-4.10.0, ddtrace-4.0.0, split-0.10.0, anyio-4.13.0
     asyncio: mode=Mode.STRICT
     collecting ... collected 9 items

     tests/test_xml.py::test_plain_text PASSED                                [ 11%]
     tests/test_xml.py::test_api PASSED                                       [ 22%]
     tests/test_xml.py::test_text PASSED                                      [ 33%]
     tests/test_xml.py::test_xmltext_embed_in_xmltext PASSED                  [ 44%]
     tests/test_xml.py::test_element_with_any_attribute PASSED                [ 55%]
     tests/test_xml.py::test_element PASSED                                   [ 66%]
     tests/test_xml.py::test_observe PASSED                                   [ 77%]
     tests/test_xml.py::test_xml_in_array PASSED                              [ 88%]
     tests/test_xml.py::test_xml_in_map PASSED                                [100%]

     ============================== 9 passed in 0.21s ===============================
```