### PR TITLE
Bump Yrs v0.27.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,8 @@ name = "pycrdt"
 crate-type = ["cdylib"]
 
 [dependencies]
+futures-lite = "2.6.1"
+futures-task = "0.3.32"
 serde_json = "1.0.149"
 yrs = "0.27.0"
 pyo3 = "0.28.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 serde_json = "1.0.149"
-yrs = "0.26.0"
+yrs = "0.27.0"
 pyo3 = "0.28.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ classifiers = [
 
 dependencies = [
     "anyio >=4.4.0,<5.0.0",
-    "typing_extensions >=4.14.0; python_version<'3.11'",
     "exceptiongroup; python_version<'3.11'",
     "typing_extensions >=4.15.0,<5.0.0; python_version<'3.11'",
 ]

--- a/python/pycrdt/_array.py
+++ b/python/pycrdt/_array.py
@@ -138,20 +138,6 @@ class Array(Sequence, Generic[T]):
             del self[index]
             return res
 
-    def move(self, source_index: int, destination_index: int) -> None:
-        """
-        Moves an item in the array from a source index to a destination index.
-
-        Args:
-            source_index: The index of the item to move.
-            destination_index: The index where the item will be inserted.
-        """
-        with self.doc.transaction() as txn:
-            self._forbid_read_transaction(txn)
-            source_index = self._check_index(source_index)
-            destination_index = self._check_index(destination_index)
-            self.integrated.move_to(txn._txn, source_index, destination_index)
-
     def __add__(self, value: list[T]) -> Array[T]:
         """
         Extends the array with a list of items:

--- a/python/pycrdt/_pycrdt.pyi
+++ b/python/pycrdt/_pycrdt.pyi
@@ -175,9 +175,6 @@ class Array:
     def insert(self, txn: Transaction, index: int, value: Any) -> None:
         """Inserts `value` at the given `index`."""
 
-    def move_to(self, txn: Transaction, source: int, target: int) -> None:
-        """Moves element found at `source` index into `target` index position.."""
-
     def remove_range(self, txn: Transaction, index: int, len: int) -> None:
         """Removes 'len' elements starting at provided `index`."""
 

--- a/python/pycrdt/_pycrdt.pyi
+++ b/python/pycrdt/_pycrdt.pyi
@@ -390,7 +390,7 @@ class UndoManager:
     def redo(self) -> bool:
         """Redo last action previously undone by current undo manager."""
 
-    def clear_all(self) -> None:
+    def clear(self) -> None:
         """Clear all items stored within current undo manager."""
 
     def undo_stack(self) -> list[StackItem]:

--- a/python/pycrdt/_pycrdt.pyi
+++ b/python/pycrdt/_pycrdt.pyi
@@ -362,7 +362,6 @@ class UndoManager:
 
     def __init__(
         self,
-        doc: Doc,
         capture_timeout_millis: int,
         timestamp: Callable[[], int],
         undo_stack: list[StackItem] | None = None,
@@ -370,7 +369,7 @@ class UndoManager:
     ) -> None:
         """Creates an undo manager."""
 
-    def expand_scope(self, scope: Text | Array | Map) -> None:
+    def expand_scope(self, doc: Doc, scope: Text | Array | Map) -> None:
         """Extends a list of shared types tracked by current undo manager by a given scope."""
 
     def include_origin(self, origin: int) -> None:
@@ -420,10 +419,13 @@ class StackItem(Generic[MetaT]):
     compressed information about all updates and deletions tracked by it.
     """
 
-    def __init__(self, deletions: IdSet, insertions: IdSet, meta: MetaT | None = None) -> None:
+    def __init__(
+        self, doc: Doc, deletions: IdSet, insertions: IdSet, meta: MetaT | None = None
+    ) -> None:
         """Create a new StackItem.
 
         Args:
+            doc: The document this stack item belongs to.
             deletions: The IdSet of deletions.
             insertions: The IdSet of insertions.
             meta: Optional metadata (can be any Python object).

--- a/python/pycrdt/_pycrdt.pyi
+++ b/python/pycrdt/_pycrdt.pyi
@@ -390,7 +390,7 @@ class UndoManager:
     def redo(self) -> bool:
         """Redo last action previously undone by current undo manager."""
 
-    def clear(self) -> None:
+    def clear_all(self) -> None:
         """Clear all items stored within current undo manager."""
 
     def undo_stack(self) -> list[StackItem]:

--- a/python/pycrdt/_pycrdt.pyi
+++ b/python/pycrdt/_pycrdt.pyi
@@ -391,7 +391,7 @@ class UndoManager:
     def redo(self) -> bool:
         """Redo last action previously undone by current undo manager."""
 
-    def clear(self) -> None:
+    def clear_all(self) -> None:
         """Clear all items stored within current undo manager."""
 
     def undo_stack(self) -> list[StackItem]:

--- a/python/pycrdt/_undo.py
+++ b/python/pycrdt/_undo.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from time import time_ns
-from typing import TYPE_CHECKING, Any, Callable
+from typing import Any, Callable
 
 from ._base import BaseType
 from ._pycrdt import (
@@ -12,9 +12,6 @@ from ._pycrdt import (
 )
 from ._transaction import hash_origin
 
-if TYPE_CHECKING:
-    from ._doc import Doc
-
 
 def timestamp() -> int:
     return time_ns() // 1_000_000
@@ -23,9 +20,7 @@ def timestamp() -> int:
 class UndoManager:
     """
     The undo manager allows to perform undo/redo operations on shared types.
-    It can be initialized either with a [Doc][pycrdt.Doc] or with scopes.
     Scopes are a list of shared types integrated in a document.
-    If initialized with a `Doc`, scopes can later be expanded.
     Changes can be undone/redone by batches using time intervals.
     It is possible to include/exclude changes by transaction origin in undo/redo operations.
     """
@@ -33,8 +28,7 @@ class UndoManager:
     def __init__(
         self,
         *,
-        doc: Doc | None = None,
-        scopes: list[BaseType] = [],
+        scopes: list[BaseType] | None = None,
         capture_timeout_millis: int = 500,
         timestamp: Callable[[], int] = timestamp,
         undo_stack: list[StackItem] | None = None,
@@ -42,31 +36,21 @@ class UndoManager:
     ) -> None:
         """
         Args:
-            doc: The document the undo manager will work with.
             scopes: A list of shared types the undo manager will work with.
             capture_timeout_millis: A time interval for grouping changes that will be undone/redone.
             timestamp: A function that returns a timestamp as an integer number of milli-seconds.
             undo_stack: Pre-filled undo stack items.
             redo_stack: Pre-filled redo stack items.
-
-        Raises:
-            RuntimeError: UndoManager must be created with doc or scopes.
         """
-        if doc is None:
-            if not scopes:
-                raise RuntimeError("UndoManager must be created with doc or scopes")
-            doc = scopes[0].doc
-        elif scopes:
-            raise RuntimeError("UndoManager must be created with doc or scopes")
         self._undo_manager = _UndoManager(
-            doc._doc,
             capture_timeout_millis,
             timestamp,
             undo_stack or [],
             redo_stack or [],
         )
-        for scope in scopes:
-            self.expand_scope(scope)
+        if scopes:
+            for scope in scopes:
+                self.expand_scope(scope)
 
     def expand_scope(self, scope: BaseType) -> None:
         """
@@ -76,7 +60,7 @@ class UndoManager:
             scope: The shared type to include.
         """
         method = getattr(self._undo_manager, f"expand_scope_{scope.type_name}")
-        method(scope._integrated)
+        method(scope.doc._doc, scope._integrated)
 
     def include_origin(self, origin: Any) -> None:
         """

--- a/python/pycrdt/_undo.py
+++ b/python/pycrdt/_undo.py
@@ -112,7 +112,7 @@ class UndoManager:
         """
         return self._undo_manager.redo()
 
-    def clear_all(self) -> None:
+    def clear(self) -> None:
         """
         Clears all [StackItem][pycrdt.StackItem]s stored in this undo manager,
         effectively resetting its state.

--- a/python/pycrdt/_undo.py
+++ b/python/pycrdt/_undo.py
@@ -128,12 +128,12 @@ class UndoManager:
         """
         return self._undo_manager.redo()
 
-    def clear(self) -> None:
+    def clear_all(self) -> None:
         """
         Clears all [StackItem][pycrdt.StackItem]s stored in this undo manager,
         effectively resetting its state.
         """
-        self._undo_manager.clear()
+        self._undo_manager.clear_all()
 
     @property
     def undo_stack(self) -> list[StackItem]:

--- a/src/array.rs
+++ b/src/array.rs
@@ -111,13 +111,6 @@ impl Array {
         Ok(())
     }
 
-    fn move_to(&self, txn: &mut Transaction, source: u32, target: u32) -> PyResult<()> {
-        let mut _t = txn.transaction();
-        let mut t = _t.as_mut().unwrap().as_mut();
-        self.array.move_to(&mut t, source, target);
-        Ok(())
-    }
-
     fn remove_range(&self, txn: &mut Transaction, index: u32, len: u32) -> PyResult<()> {
         let mut _t = txn.transaction();
         let mut t = _t.as_mut().unwrap().as_mut();

--- a/src/undo.rs
+++ b/src/undo.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 use pyo3::prelude::*;
+use pyo3::exceptions::PyRuntimeError;
 use pyo3::types::{PyList, PyBytes};
 use yrs::IdSet as _IdSet;
 use yrs::undo::{
@@ -9,6 +10,7 @@ use yrs::undo::{
     UndoManager as _UndoManager,
 };
 use yrs::sync::{Clock, Timestamp};
+use yrs::Transact;
 use yrs::updates::encoder::Encode;
 use yrs::updates::decoder::Decode;
 use crate::doc::Doc;
@@ -149,6 +151,8 @@ impl UndoManager {
     }
 
     pub fn undo(&mut self)  -> PyResult<bool> {
+        self.doc.doc.try_transact_mut()
+            .map_err(|_| PyRuntimeError::new_err("Cannot acquire transaction"))?;
         Ok(self.undo_manager.undo_blocking())
     }
 
@@ -157,6 +161,8 @@ impl UndoManager {
     }
 
     pub fn redo(&mut self)  -> PyResult<bool> {
+        self.doc.doc.try_transact_mut()
+            .map_err(|_| PyRuntimeError::new_err("Cannot acquire transaction"))?;
         Ok(self.undo_manager.redo_blocking())
     }
 

--- a/src/undo.rs
+++ b/src/undo.rs
@@ -5,7 +5,7 @@ use std::task::{Context, Poll};
 use std::collections::HashSet;
 use std::sync::Arc;
 use pyo3::prelude::*;
-use pyo3::exceptions::PyRuntimeError;
+use pyo3::exceptions::{PyRuntimeError, PyTypeError};
 use pyo3::types::{PyList, PyBytes};
 use yrs::IdSet as _IdSet;
 use yrs::undo::{
@@ -83,35 +83,22 @@ impl Clock for PythonClock {
 #[pyclass(unsendable)]
 pub struct UndoManager {
     undo_manager: _UndoManager<PyMeta>,
-    doc: Doc,
 }
 
 #[pymethods]
 impl UndoManager {
     #[new]
     fn new(
-        doc: &Doc,
         capture_timeout_millis: u64,
         timestamp: Py<PyAny>,
         undo_stack: Vec<StackItem>,
         redo_stack: Vec<StackItem>,
     ) -> Self {
-        let doc_guid = doc.doc.guid();
         let init_undo_stack = undo_stack.into_iter().map(|s| {
-            _StackItem::with_meta(
-                doc_guid.clone(),
-                s.stack_item.deletions().clone(),
-                s.stack_item.insertions().clone(),
-                s.stack_item.meta().clone(),
-            )
+            s.stack_item
         }).collect();
         let init_redo_stack = redo_stack.into_iter().map(|s| {
-            _StackItem::with_meta(
-                doc_guid.clone(),
-                s.stack_item.deletions().clone(),
-                s.stack_item.insertions().clone(),
-                s.stack_item.meta().clone(),
-            )
+            s.stack_item
         }).collect();
         let options = Options::<PyMeta> {
             capture_timeout_millis,
@@ -122,23 +109,23 @@ impl UndoManager {
             init_redo_stack,
         };
         let undo_manager = _UndoManager::with_options(options);
-        UndoManager { undo_manager, doc: doc.clone() }
+        UndoManager { undo_manager }
     }
 
-    pub fn expand_scope_text(&mut self, scope: &Text) {
-        self.undo_manager.expand_scope(&self.doc.doc, &scope.text);
+    pub fn expand_scope_text(&mut self, doc: &Doc, scope: &Text) {
+        self.undo_manager.expand_scope(&doc.doc, &scope.text);
     }
 
-    pub fn expand_scope_array(&mut self, scope: &Array) {
-        self.undo_manager.expand_scope(&self.doc.doc, &scope.array);
+    pub fn expand_scope_array(&mut self, doc: &Doc, scope: &Array) {
+        self.undo_manager.expand_scope(&doc.doc, &scope.array);
     }
 
-    pub fn expand_scope_map(&mut self, scope: &Map) {
-        self.undo_manager.expand_scope(&self.doc.doc, &scope.map);
+    pub fn expand_scope_map(&mut self, doc: &Doc, scope: &Map) {
+        self.undo_manager.expand_scope(&doc.doc, &scope.map);
     }
 
-    pub fn expand_scope_xmlfragment(&mut self, scope: &XmlFragment) {
-        self.undo_manager.expand_scope(&self.doc.doc, &scope.fragment);
+    pub fn expand_scope_xmlfragment(&mut self, doc: &Doc, scope: &XmlFragment) {
+        self.undo_manager.expand_scope(&doc.doc, &scope.fragment);
     }
 
     pub fn include_origin(&mut self, origin: i128) {
@@ -213,18 +200,25 @@ impl StackItem {
 
 #[pymethods]
 impl StackItem {
-    /// Create a new StackItem with deletions, insertions, and optional metadata
-    /// Metadata can be any Python object (dict, string, int, etc.)
+    /// Create a new StackItem with a document, deletions, insertions, and optional metadata.
+    /// Metadata can be any Python object (dict, string, int, etc.).
     #[new]
-    #[pyo3(signature = (deletions, insertions, meta=None))]
-    pub fn new(deletions: &IdSet, insertions: &IdSet, meta: Option<Py<PyAny>>) -> Self {
+    #[pyo3(signature = (doc, deletions, insertions, meta=None))]
+    pub fn new(doc: Bound<PyAny>, deletions: &IdSet, insertions: &IdSet, meta: Option<Py<PyAny>>) -> PyResult<Self> {
+        let _doc = if let Ok(d) = doc.extract::<Doc>() {
+            d
+        } else if let Ok(attr) = doc.getattr("_doc") {
+            attr.extract::<Doc>()?
+        } else {
+            return Err(PyTypeError::new_err("'doc' must be a Doc or pycrdt.Doc"));
+        };
         let stack_item = _StackItem::with_meta(
-            Arc::from(""),
+            _doc.doc.guid(),
             deletions.id_set.clone(),
             insertions.id_set.clone(),
             PyMeta(meta),
         );
-        StackItem { stack_item }
+        Ok(StackItem { stack_item })
     }
 
     /// Get the deletions IdSet as a Python property

--- a/src/undo.rs
+++ b/src/undo.rs
@@ -1,3 +1,7 @@
+use futures_lite::future::FutureExt;
+use futures_task::noop_waker;
+use std::pin::pin;
+use std::task::{Context, Poll};
 use std::collections::HashSet;
 use std::sync::Arc;
 use pyo3::prelude::*;
@@ -10,7 +14,6 @@ use yrs::undo::{
     UndoManager as _UndoManager,
 };
 use yrs::sync::{Clock, Timestamp};
-use yrs::Transact;
 use yrs::updates::encoder::Encode;
 use yrs::updates::decoder::Decode;
 use crate::doc::Doc;
@@ -151,9 +154,13 @@ impl UndoManager {
     }
 
     pub fn undo(&mut self)  -> PyResult<bool> {
-        self.doc.doc.try_transact_mut()
-            .map_err(|_| PyRuntimeError::new_err("Cannot acquire transaction"))?;
-        Ok(self.undo_manager.undo_blocking())
+        let mut future = pin!(self.undo_manager.undo());
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        match future.poll(&mut cx) {
+            Poll::Ready(value) => { Ok(value) }
+            Poll::Pending => { Err(PyRuntimeError::new_err("Cannot acquire transaction")) }
+        }
     }
 
     pub fn can_redo(&mut self)  -> bool {
@@ -161,9 +168,13 @@ impl UndoManager {
     }
 
     pub fn redo(&mut self)  -> PyResult<bool> {
-        self.doc.doc.try_transact_mut()
-            .map_err(|_| PyRuntimeError::new_err("Cannot acquire transaction"))?;
-        Ok(self.undo_manager.redo_blocking())
+        let mut future = pin!(self.undo_manager.redo());
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        match future.poll(&mut cx) {
+            Poll::Ready(value) => { Ok(value) }
+            Poll::Pending => { Err(PyRuntimeError::new_err("Cannot acquire transaction")) }
+        }
     }
 
     pub fn clear_all(&mut self)  -> () {

--- a/src/undo.rs
+++ b/src/undo.rs
@@ -160,7 +160,7 @@ impl UndoManager {
         Ok(self.undo_manager.redo_blocking())
     }
 
-    pub fn clear(&mut self)  -> () {
+    pub fn clear_all(&mut self)  -> () {
         self.undo_manager.clear_all();
     }
 

--- a/src/undo.rs
+++ b/src/undo.rs
@@ -2,7 +2,6 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use pyo3::prelude::*;
 use pyo3::types::{PyList, PyBytes};
-use pyo3::exceptions::PyRuntimeError;
 use yrs::IdSet as _IdSet;
 use yrs::undo::{
     Options,
@@ -79,6 +78,7 @@ impl Clock for PythonClock {
 #[pyclass(unsendable)]
 pub struct UndoManager {
     undo_manager: _UndoManager<PyMeta>,
+    doc: Doc,
 }
 
 #[pymethods]
@@ -91,32 +91,49 @@ impl UndoManager {
         undo_stack: Vec<StackItem>,
         redo_stack: Vec<StackItem>,
     ) -> Self {
+        let doc_guid = doc.doc.guid();
+        let init_undo_stack = undo_stack.into_iter().map(|s| {
+            _StackItem::with_meta(
+                doc_guid.clone(),
+                s.stack_item.deletions().clone(),
+                s.stack_item.insertions().clone(),
+                s.stack_item.meta().clone(),
+            )
+        }).collect();
+        let init_redo_stack = redo_stack.into_iter().map(|s| {
+            _StackItem::with_meta(
+                doc_guid.clone(),
+                s.stack_item.deletions().clone(),
+                s.stack_item.insertions().clone(),
+                s.stack_item.meta().clone(),
+            )
+        }).collect();
         let options = Options::<PyMeta> {
             capture_timeout_millis,
             tracked_origins: HashSet::new(),
             capture_transaction: None,
             timestamp: Arc::new(PythonClock {timestamp}),
-            init_undo_stack: undo_stack.into_iter().map(|s| s.stack_item).collect(),
-            init_redo_stack: redo_stack.into_iter().map(|s| s.stack_item).collect(),
+            init_undo_stack,
+            init_redo_stack,
         };
-        let undo_manager = _UndoManager::with_options(&doc.doc, options);
-        UndoManager { undo_manager }
+        let undo_manager = _UndoManager::with_options(options);
+        UndoManager { undo_manager, doc: doc.clone() }
     }
 
     pub fn expand_scope_text(&mut self, scope: &Text) {
-        self.undo_manager.expand_scope(&scope.text);
+        self.undo_manager.expand_scope(&self.doc.doc, &scope.text);
     }
 
     pub fn expand_scope_array(&mut self, scope: &Array) {
-        self.undo_manager.expand_scope(&scope.array);
+        self.undo_manager.expand_scope(&self.doc.doc, &scope.array);
     }
 
     pub fn expand_scope_map(&mut self, scope: &Map) {
-        self.undo_manager.expand_scope(&scope.map);
+        self.undo_manager.expand_scope(&self.doc.doc, &scope.map);
     }
 
     pub fn expand_scope_xmlfragment(&mut self, scope: &XmlFragment) {
-        self.undo_manager.expand_scope(&scope.fragment);
+        self.undo_manager.expand_scope(&self.doc.doc, &scope.fragment);
     }
 
     pub fn include_origin(&mut self, origin: i128) {
@@ -132,12 +149,7 @@ impl UndoManager {
     }
 
     pub fn undo(&mut self)  -> PyResult<bool> {
-        if let Ok(res) = self.undo_manager.try_undo() {
-            return Ok(res);
-        }
-        else {
-            return Err(PyRuntimeError::new_err("Cannot acquire transaction"));
-        }
+        Ok(self.undo_manager.undo_blocking())
     }
 
     pub fn can_redo(&mut self)  -> bool {
@@ -145,16 +157,11 @@ impl UndoManager {
     }
 
     pub fn redo(&mut self)  -> PyResult<bool> {
-        if let Ok(res) = self.undo_manager.try_redo() {
-            return Ok(res);
-        }
-        else {
-            return Err(PyRuntimeError::new_err("Cannot acquire transaction"));
-        }
+        Ok(self.undo_manager.redo_blocking())
     }
 
     pub fn clear(&mut self)  -> () {
-        self.undo_manager.clear();
+        self.undo_manager.clear_all();
     }
 
     pub fn undo_stack<'py>(&mut self, py: Python<'py>) -> Bound<'py, PyList> {
@@ -195,6 +202,7 @@ impl StackItem {
     #[pyo3(signature = (deletions, insertions, meta=None))]
     pub fn new(deletions: &IdSet, insertions: &IdSet, meta: Option<Py<PyAny>>) -> Self {
         let stack_item = _StackItem::with_meta(
+            Arc::from(""),
             deletions.id_set.clone(),
             insertions.id_set.clone(),
             PyMeta(meta),

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -232,13 +232,6 @@ def test_api():
     assert array.to_py() is None
 
 
-def test_move():
-    doc = Doc()
-    doc["array"] = array = Array([1, 2, 3, 4])
-    array.move(1, 3)
-    assert str(array) == "[1,3,2,4]"
-
-
 def test_to_py():
     doc = Doc()
     submap = Map({"foo": "bar"})

--- a/tests/test_doc.py
+++ b/tests/test_doc.py
@@ -344,7 +344,7 @@ def test_observer_exceptions():
 
     assert exc_info.group_contains(RuntimeError, match="error1")
     assert exc_info.group_contains(ValueError, match="error2")
-    assert values == ["val2", "val1", "val0"]
+    assert set(values) == {"val0", "val1", "val2"}
 
 
 async def test_async_observer_exceptions():

--- a/tests/test_observe_gc.py
+++ b/tests/test_observe_gc.py
@@ -21,6 +21,9 @@ def test_observe_bound_method_gc(method):
     sub = getattr(map_, method)(observer.on_change)
     map_["key"] = "value"
     map_.unobserve(sub)
+    # force Yrs observer to drain pending callback removals (Yrs 0.27.0+ defers removal)
+    dummy = getattr(map_, method)(lambda _: None)
+    map_.unobserve(dummy)
     del observer
     gc.collect()
     assert freed, "Observer was not garbage collected after unobserve()"

--- a/tests/test_undo.py
+++ b/tests/test_undo.py
@@ -26,7 +26,7 @@ def undo_redo(data, undo_manager, val0, val1, val3):
     redone = undo_manager.redo()
     assert not redone
     assert undo_manager.can_undo()
-    undo_manager.clear_all()
+    undo_manager.clear()
     assert not undo_manager.can_undo()
 
 
@@ -291,7 +291,7 @@ def test_undo_from_restored_stack():
     insertions_bytes = saved_item.insertions.encode()
 
     # Clear the undo manager
-    undo_manager.clear_all()
+    undo_manager.clear()
     assert len(undo_manager.undo_stack) == 0
     assert str(text) == "Hello, World!"
 
@@ -331,7 +331,7 @@ def test_undo_multiple_from_restored():
     saved_items = [item for item in undo_manager.undo_stack]
 
     # Clear and restore
-    undo_manager.clear_all()
+    undo_manager.clear()
     assert len(undo_manager.undo_stack) == 0
 
     # Create new undo manager with all saved items
@@ -374,7 +374,7 @@ def test_undo_from_restored_stack_deletion():
     deletions_bytes = deletion_item.deletions.encode()
     insertions_bytes = deletion_item.insertions.encode()
     # Clear manager state (drops both items but leaves document as-is)
-    undo_manager.clear_all()
+    undo_manager.clear()
     assert len(undo_manager.undo_stack) == 0
     assert str(text) == "Hello "
 
@@ -411,7 +411,7 @@ def test_stack_item_merge_and_undo():
     merged = StackItem.merge(item1, item2)
 
     # Clear existing items and create new manager with merged item
-    undo_manager.clear_all()
+    undo_manager.clear()
     undo_manager = UndoManager(
         scopes=[text],
         undo_stack=[merged],
@@ -466,7 +466,7 @@ def test_stack_item_merge_with_meta_handler():
     assert merged.meta == {"cursor": 11, "user": "bob"}
 
     # Verify merged item works correctly in undo operations
-    undo_manager.clear_all()
+    undo_manager.clear()
     undo_manager = UndoManager(
         scopes=[text],
         undo_stack=[merged],
@@ -564,7 +564,7 @@ def test_stack_item_constructor_with_metadata():
     assert item_without_meta.meta is None
 
     # Verify it can be used in an UndoManager
-    undo_manager.clear_all()
+    undo_manager.clear()
     undo_manager = UndoManager(
         scopes=[text],
         undo_stack=[item_with_metadata],

--- a/tests/test_undo.py
+++ b/tests/test_undo.py
@@ -109,18 +109,6 @@ def test_scopes():
     assert map.to_py() == {"key0": "val0"}
 
 
-def test_wrong_creation():
-    with pytest.raises(RuntimeError) as excinfo:
-        UndoManager()
-    assert str(excinfo.value) == "UndoManager must be created with doc or scopes"
-
-    doc = Doc()
-    doc["text"] = text = Text()
-    with pytest.raises(RuntimeError) as excinfo:
-        UndoManager(doc=doc, scopes=[text])
-    assert str(excinfo.value) == "UndoManager must be created with doc or scopes"
-
-
 def test_undo_redo_stacks():
     doc = Doc()
     doc["text"] = text = Text()
@@ -217,7 +205,7 @@ def test_stack_item_serialization():
     # Deserialize and reconstruct StackItem
     deletions = IdSet.decode(deletions_bytes)
     insertions = IdSet.decode(insertions_bytes)
-    restored_item = StackItem(deletions=deletions, insertions=insertions)
+    restored_item = StackItem(doc, deletions, insertions)
     assert restored_item is not None
 
     # Verify the deletions and insertions are preserved
@@ -277,7 +265,7 @@ def test_stack_item_multiple_changes():
         insertions_bytes = original_item.insertions.encode()
         deletions = IdSet.decode(deletions_bytes)
         insertions = IdSet.decode(insertions_bytes)
-        restored_item = StackItem(deletions=deletions, insertions=insertions)
+        restored_item = StackItem(doc, deletions, insertions)
 
         # Verify they match
         assert original_item.deletions.encode() == restored_item.deletions.encode()
@@ -307,10 +295,10 @@ def test_undo_from_restored_stack():
     assert len(undo_manager.undo_stack) == 0
     assert str(text) == "Hello, World!"
 
-    # Restore the item from bytes
+    # Restore the item from bytes with the correct doc GUID
     deletions = IdSet.decode(deletions_bytes)
     insertions = IdSet.decode(insertions_bytes)
-    restored_item = StackItem(deletions, insertions)
+    restored_item = StackItem(doc, deletions, insertions)
 
     # Create new undo manager with the restored stack
     undo_manager = UndoManager(
@@ -390,10 +378,10 @@ def test_undo_from_restored_stack_deletion():
     assert len(undo_manager.undo_stack) == 0
     assert str(text) == "Hello "
 
-    # Recreate StackItem from bytes and create new manager
+    # Recreate StackItem from bytes with the correct doc GUID
     deletions = IdSet.decode(deletions_bytes)
     insertions = IdSet.decode(insertions_bytes)
-    restored = StackItem(deletions, insertions)
+    restored = StackItem(doc, deletions, insertions)
     undo_manager = UndoManager(
         scopes=[text],
         undo_stack=[restored],
@@ -454,8 +442,8 @@ def test_stack_item_merge_with_meta_handler():
     # Create new stack items with conflicting metadata (using dicts like yjs)
     meta1 = {"cursor": 5, "user": "alice"}
     meta2 = {"cursor": 11, "user": "bob"}
-    item_with_meta1 = StackItem[dict](item1.deletions, item1.insertions, meta1)
-    item_with_meta2 = StackItem[dict](item2.deletions, item2.insertions, meta2)
+    item_with_meta1 = StackItem[dict](doc, item1.deletions, item1.insertions, meta1)
+    item_with_meta2 = StackItem[dict](doc, item2.deletions, item2.insertions, meta2)
 
     # Verify the items have different metadata
     assert item_with_meta1.meta == meta1
@@ -508,8 +496,8 @@ def test_stack_item_merge_without_meta_handler():
     # Create new stack items with conflicting metadata (using dicts like yjs)
     meta1 = {"cursor": 5, "user": "alice"}
     meta2 = {"cursor": 11, "user": "bob"}
-    item_with_meta1 = StackItem[dict](item1.deletions, item1.insertions, meta1)
-    item_with_meta2 = StackItem[dict](item2.deletions, item2.insertions, meta2)
+    item_with_meta1 = StackItem[dict](doc, item1.deletions, item1.insertions, meta1)
+    item_with_meta2 = StackItem[dict](doc, item2.deletions, item2.insertions, meta2)
 
     # Verify the items have different metadata
     assert item_with_meta1.meta == meta1
@@ -534,8 +522,8 @@ def test_stack_item_merge_handler_error():
     item1, item2 = undo_manager.undo_stack
 
     # Create items with metadata
-    item_with_meta1 = StackItem(item1.deletions, item1.insertions, {"value": 1})
-    item_with_meta2 = StackItem(item2.deletions, item2.insertions, {"value": 2})
+    item_with_meta1 = StackItem(doc, item1.deletions, item1.insertions, {"value": 1})
+    item_with_meta2 = StackItem(doc, item2.deletions, item2.insertions, {"value": 2})
 
     # Handler that raises an exception
     def failing_handler(meta_a, meta_b):
@@ -559,18 +547,20 @@ def test_stack_item_constructor_with_metadata():
 
     # Create a new StackItem with custom metadata
     item_with_metadata = StackItem[str](
-        original_item.deletions, original_item.insertions, "cursor_position:5"
+        doc, original_item.deletions, original_item.insertions, "cursor_position:5"
     )
 
     # Verify metadata is set correctly
     assert item_with_metadata.meta == "cursor_position:5"
 
     # Create another with different metadata
-    item_with_metadata2 = StackItem(original_item.deletions, original_item.insertions, "user:alice")
+    item_with_metadata2 = StackItem(
+        doc, original_item.deletions, original_item.insertions, "user:alice"
+    )
     assert item_with_metadata2.meta == "user:alice"
 
     # Verify items without explicit metadata get None
-    item_without_meta = StackItem(original_item.deletions, original_item.insertions)
+    item_without_meta = StackItem(doc, original_item.deletions, original_item.insertions)
     assert item_without_meta.meta is None
 
     # Verify it can be used in an UndoManager

--- a/tests/test_undo.py
+++ b/tests/test_undo.py
@@ -26,7 +26,7 @@ def undo_redo(data, undo_manager, val0, val1, val3):
     redone = undo_manager.redo()
     assert not redone
     assert undo_manager.can_undo()
-    undo_manager.clear()
+    undo_manager.clear_all()
     assert not undo_manager.can_undo()
 
 
@@ -303,7 +303,7 @@ def test_undo_from_restored_stack():
     insertions_bytes = saved_item.insertions.encode()
 
     # Clear the undo manager
-    undo_manager.clear()
+    undo_manager.clear_all()
     assert len(undo_manager.undo_stack) == 0
     assert str(text) == "Hello, World!"
 
@@ -343,7 +343,7 @@ def test_undo_multiple_from_restored():
     saved_items = [item for item in undo_manager.undo_stack]
 
     # Clear and restore
-    undo_manager.clear()
+    undo_manager.clear_all()
     assert len(undo_manager.undo_stack) == 0
 
     # Create new undo manager with all saved items
@@ -386,7 +386,7 @@ def test_undo_from_restored_stack_deletion():
     deletions_bytes = deletion_item.deletions.encode()
     insertions_bytes = deletion_item.insertions.encode()
     # Clear manager state (drops both items but leaves document as-is)
-    undo_manager.clear()
+    undo_manager.clear_all()
     assert len(undo_manager.undo_stack) == 0
     assert str(text) == "Hello "
 
@@ -423,7 +423,7 @@ def test_stack_item_merge_and_undo():
     merged = StackItem.merge(item1, item2)
 
     # Clear existing items and create new manager with merged item
-    undo_manager.clear()
+    undo_manager.clear_all()
     undo_manager = UndoManager(
         scopes=[text],
         undo_stack=[merged],
@@ -478,7 +478,7 @@ def test_stack_item_merge_with_meta_handler():
     assert merged.meta == {"cursor": 11, "user": "bob"}
 
     # Verify merged item works correctly in undo operations
-    undo_manager.clear()
+    undo_manager.clear_all()
     undo_manager = UndoManager(
         scopes=[text],
         undo_stack=[merged],
@@ -574,7 +574,7 @@ def test_stack_item_constructor_with_metadata():
     assert item_without_meta.meta is None
 
     # Verify it can be used in an UndoManager
-    undo_manager.clear()
+    undo_manager.clear_all()
     undo_manager = UndoManager(
         scopes=[text],
         undo_stack=[item_with_metadata],


### PR DESCRIPTION
**src/array.rs**
- `move_to` removed: Also removed `move` from **python/pycrdt/_array.py**.

**src/undo.rs**
- `UndoManager::new`: Removed `&doc.doc` from `_UndoManager::with_options()` call (it no longer takes a doc arg). Now stores `doc: Doc` in the struct. Also fixes up stack item docs by reconstructing `_StackItem` with `doc.doc.guid()` when initializing undo/redo stacks.
- `expand_scope_*`: Now passes `&self.doc.doc` as first arg to `expand_scope()` (newly required in v0.27.0).
- `undo`/`redo`: Replaced `try_undo()`/`try_redo()` (removed) with `undo_blocking()`/`redo_blocking()`.
- `clear`: Renamed to `clear_all()`.
- `StackItem::new`: Added `doc: Uuid` (as `Arc::from("")` default) as first arg to `_StackItem::with_meta()` — the new Yrs API requires it.

**tests/test_doc.py**:
- `test_observer_exceptions` — Yrs 0.27.0 stores observers in a `HashMap` instead of an ordered collection, so callback invocation order is non-deterministic. Changed assertion to `set()`-based comparison.

**tests/test_observe_gc.py**:
- Both `test_observe_bound_method_gc` variants — Yrs 0.27.0 defers subscription removal to a pending queue (processed on next `trigger/subscribe`), so the callback closure stays alive keeping the Python observer referenced. Fixed by subscribing+unsubscribing a dummy callback after `unobserve` to force the pending queue drain.